### PR TITLE
Fix rel link to incremental_kernel

### DIFF
--- a/README.org
+++ b/README.org
@@ -10,5 +10,5 @@ Incremental can be useful in a number of applications, including:
 - Building online versions of existing combinatorial algorithms.
 
 You can find detailed documentation in of the library and how to use
-it in [[../incremental_kernel/blob/master/src/incremental_intf.ml][incremental_kernel/src/incremental_intf.ml]].  You can also find an informal
+it in [[../../../incremental_kernel/blob/master/src/incremental_intf.ml][incremental_kernel/src/incremental_intf.ml]].  You can also find an informal
 introduction to the library in this [[https://blogs.janestreet.com/introducing-incremental/%20][blog post]].


### PR DESCRIPTION
It seems #3 didn't work after all. I ended up forking `incremental_kernel` as well, and doing the change on master [to make sure](https://github.com/pacemkr/incremental)... 