### PR TITLE
Fix broken link to documentation in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -10,7 +10,7 @@ Incremental can be useful in a number of applications, including:
 - Building online versions of existing combinatorial algorithms.
 
 You can find detailed documentation of the library and how to use
-it in [incremental_kernel/src/incremental_intf.ml](https://github.com/janestreet/incremental_kernel/blob/master/src/incremental_intf.ml).  You can also find an informal
+it in [https://github.com/janestreet/incremental_kernel/blob/master/src/incremental_intf.ml](incremental_kernel/src/incremental_intf.ml).  You can also find an informal
 introduction to the library in this [[https://blogs.janestreet.com/introducing-incremental/%20][blog post]].
 
 

--- a/README.org
+++ b/README.org
@@ -10,7 +10,7 @@ Incremental can be useful in a number of applications, including:
 - Building online versions of existing combinatorial algorithms.
 
 You can find detailed documentation of the library and how to use
-it in [https://github.com/janestreet/incremental_kernel/blob/master/src/incremental_intf.ml](incremental_kernel/src/incremental_intf.ml).  You can also find an informal
+it in [[https://github.com/janestreet/incremental_kernel/blob/master/src/incremental_intf.ml][incremental_kernel/src/incremental_intf.ml]].  You can also find an informal
 introduction to the library in this [[https://blogs.janestreet.com/introducing-incremental/%20][blog post]].
 
 

--- a/README.org
+++ b/README.org
@@ -9,6 +9,8 @@ Incremental can be useful in a number of applications, including:
   efficiently.
 - Building online versions of existing combinatorial algorithms.
 
-You can find detailed documentation in of the library and how to use
-it in [[../incremental_kernel/blob/master/src/incremental_intf.ml][incremental_kernel/src/incremental_intf.ml]].  You can also find an informal
+You can find detailed documentation of the library and how to use
+it in [incremental_kernel/src/incremental_intf.ml](https://github.com/janestreet/incremental_kernel/blob/master/src/incremental_intf.ml).  You can also find an informal
 introduction to the library in this [[https://blogs.janestreet.com/introducing-incremental/%20][blog post]].
+
+


### PR DESCRIPTION
Just realized that #4 also fixes the issue with a relative link instead.

This pull request includes a small grammar fix as well.