### PR TITLE
fix url of blog post

### DIFF
--- a/README.org
+++ b/README.org
@@ -11,4 +11,4 @@ Incremental can be useful in a number of applications, including:
 
 You can find detailed documentation in of the library and how to use
 it in [[../incremental_kernel/blob/master/src/incremental_intf.ml][incremental_kernel/src/incremental_intf.ml]].  You can also find an informal
-introduction to the library in this [[https://blogs.janestreet.com/introducing-incremental/%20][blog post]].
+introduction to the library in this [[https://blogs.janestreet.com/introducing-incremental][blog post]].


### PR DESCRIPTION
The old link to the blog post introducing incremental didn't work for me. After this change, it does.