### PR TITLE
README: Factual corrections.

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,13 +1,12 @@
-A library for building self-adjusting computations, following the work
-of [[http://www.umut-acar.org/self-adjusting-computation][Umut Acar et. al.]]. Incremental gives you a way of building complex
-computations that can update efficiently in response to their inputs.
+A library for building a restricted class of incremental computations, inspired by the work
+of [[http://www.umut-acar.org/self-adjusting-computation][Umut Acar et. al.]]. Incremental gives you a way of building
+computations that can update in response to their inputs.
 Incremental can be useful in a number of applications, including:
 
 - Building large calculations (of the kind you might build into a
   spreadsheet) that can react efficiently to changing data.
 - Constructing views in GUI applications that can incorporate new data
   efficiently.
-- Building online versions of existing combinatorial algorithms.
 
 You can find detailed documentation in of the library and how to use
 it in [[https://github.com/janestreet/incremental/blob/master/src/incremental_intf.ml][incremental/src/incremental_intf.ml]].  You can also find an


### PR DESCRIPTION
The README file (and the blog post it references) make a lot of reference to "self-adjusting computation" (SAC).

*However, the authors of this library are misrepresenting SAC by saying that they have implemented it.  They have not.*

They have implemented _something_, and seemingly, something useful, but they should stop comparing it to SAC unless they want to do a real comparison, like scientists.  I myself know what self-adjusting computation is, having written a PhD dissertation on it, advised by Umut Acar.  The kind of comparison that would warrant using this term here is missing, and so I'd strongly advise accepting this PR, and ceasing to call what this library does "SAC", since it is not the same thing, and it's both confusing and upsetting to people who understand the difference.

Second, in addition to misusing "SAC", this library also has a poorly-chosen (and audacious) name.  "Incremental" is part of a name, but fails to be an adequate software package name on its own.  It succeeds at being confusing, much like the use of "SAC" mentioned above.  This PR does not address this second issue.  Sadly, it seems like it's beyond the scope of any one PR.