### PR TITLE
docs: use Org-mode link syntax for video link in README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -15,4 +15,4 @@ including:
 You can find detailed documentation of the library and how to use
 it in [[https://github.com/janestreet/incremental/blob/master/src/incremental_intf.ml][incremental/src/incremental_intf.ml]].  You can also find an
 informal introduction to the library in this [[https://blog.janestreet.com/introducing-incremental][blog post]]
-and [this video](https://www.youtube.com/watch?v=G6a5G5i4gQU).
+and [[https://www.youtube.com/watch?v=G6a5G5i4gQU][this video]].


### PR DESCRIPTION
Fixes #17.

The video link in `README.org` was written with Markdown link syntax (`[text](url)`) in a `.org` file, so GitHub's org-ruby renderer displayed it as literal text rather than a clickable link. The surrounding blog-post and source-file links already use correct Org syntax (`[[url][text]]`).

```diff
-and [this video](https://www.youtube.com/watch?v=G6a5G5i4gQU).
+and [[https://www.youtube.com/watch?v=G6a5G5i4gQU][this video]].
```